### PR TITLE
Rename subpackage from e-antic to libeantic

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -12,14 +12,17 @@ jobs:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        SHORT_CONFIG_NAME: linux_64_
       linux_aarch64_:
         CONFIG: linux_aarch64_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        SHORT_CONFIG_NAME: linux_aarch64_
       linux_ppc64le_:
         CONFIG: linux_ppc64le_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        SHORT_CONFIG_NAME: linux_ppc64le_
   timeoutInMinutes: 360
 
   steps:
@@ -46,3 +49,15 @@ jobs:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
       FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
       STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)
+  - script: |
+        artifact_name="conda_artifacts_$(build.BuildId)_$(SHORT_CONFIG_NAME)"
+        echo "##vso[task.setVariable variable=ARTIFACT_NAME]$artifact_name"
+        if [ -d build_artifacts ]; then
+          echo "##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true"
+        fi
+    displayName: Check for conda build artifacts
+    condition: succeededOrFailed()
+
+  - publish: build_artifacts/
+    artifact: $(ARTIFACT_NAME)
+    condition: eq(variables.CONDA_BLD_DIR_EXISTS, 'true')

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -11,9 +11,11 @@ jobs:
       osx_64_:
         CONFIG: osx_64_
         UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG_NAME: osx_64_
       osx_arm64_:
         CONFIG: osx_arm64_
         UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG_NAME: osx_arm64_
   timeoutInMinutes: 360
 
   steps:
@@ -29,3 +31,15 @@ jobs:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
       FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
       STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)
+  - script: |
+        artifact_name="conda_artifacts_$(build.BuildId)_$(SHORT_CONFIG_NAME)"
+        echo "##vso[task.setVariable variable=ARTIFACT_NAME]$artifact_name"
+        if [ -d /Users/runner/miniforge3/conda-bld/ ]; then
+          echo "##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true"
+        fi
+    displayName: Check for conda build artifacts
+    condition: succeededOrFailed()
+
+  - publish: /Users/runner/miniforge3/conda-bld/
+    artifact: $(ARTIFACT_NAME)
+    condition: eq(variables.CONDA_BLD_DIR_EXISTS, 'true')

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/e-antic-feedsto
 
 Summary: embedded algebraic number fields
 
-Development: https://github.com/videlec/e-antic
+Development: https://github.com/flatsurf/e-antic
 
-E-ANTIC is a C/C++ library to deal with real embedded number fields built
-on top of ANTIC. Its aim is to have as fast as possible exact arithmetic
+e-antic is a C/C++ library to deal with real embedded number fields built
+on top of ANTIC. It aims to privode the fastest possible exact arithmetic
 operations and comparisons.
 
 
@@ -81,7 +81,7 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-e--antic-green.svg)](https://anaconda.org/conda-forge/e-antic) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/e-antic.svg)](https://anaconda.org/conda-forge/e-antic) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/e-antic.svg)](https://anaconda.org/conda-forge/e-antic) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/e-antic.svg)](https://anaconda.org/conda-forge/e-antic) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-libeantic-green.svg)](https://anaconda.org/conda-forge/libeantic) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libeantic.svg)](https://anaconda.org/conda-forge/libeantic) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libeantic.svg)](https://anaconda.org/conda-forge/libeantic) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libeantic.svg)](https://anaconda.org/conda-forge/libeantic) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-pyeantic-green.svg)](https://anaconda.org/conda-forge/pyeantic) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pyeantic.svg)](https://anaconda.org/conda-forge/pyeantic) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pyeantic.svg)](https://anaconda.org/conda-forge/pyeantic) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pyeantic.svg)](https://anaconda.org/conda-forge/pyeantic) |
 
 Installing e-antic
@@ -94,16 +94,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `e-antic, pyeantic` can be installed with:
+Once the `conda-forge` channel has been enabled, `libeantic, pyeantic` can be installed with:
 
 ```
-conda install e-antic pyeantic
+conda install libeantic pyeantic
 ```
 
-It is possible to list all of the versions of `e-antic` available on your platform with:
+It is possible to list all of the versions of `libeantic` available on your platform with:
 
 ```
-conda search e-antic --channel conda-forge
+conda search libeantic --channel conda-forge
 ```
 
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,3 +4,5 @@ build_platform:
   osx_arm64: osx_64
 conda_forge_output_validation: true
 test_on_native_only: true
+azure:
+  store_build_artifacts: true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set name = "E-ANTIC" %}
+{% set name = "e-antic" %}
 {% set version = "1.0.2" %}
 
 package:
@@ -10,16 +10,16 @@ source:
   sha256: 17a47fad2d945c6282e8c9037f3e1fdfda62e50fff3605b73af42c37ceb35dd4
 
 build:
-  number: 0
+  number: 1
   # Upstream doesn't support MSVC yet.
   skip: true  # [win]
 
 outputs:
-  - name: e-antic
+  - name: libeantic
     script: build-libeantic.sh
     run_exports:
       # e-antic uses semantic versioning https://github.com/videlec/e-antic/issues/12
-      - {{ pin_subpackage("e-antic") }}
+      - {{ pin_subpackage("libeantic") }}
     requirements:
       build:
         - libtool   # [unix]
@@ -61,7 +61,7 @@ outputs:
         - cppyythonizations
         - setuptools
         - pytest
-        - {{ pin_subpackage("e-antic") }}
+        - {{ pin_subpackage("libeantic") }}
       run:
         - boost-cpp
         - python
@@ -69,7 +69,7 @@ outputs:
         - cppyythonizations
         # A subpackage does not see the run_exports of another subpackage:
         # https://github.com/conda/conda-build/issues/3478
-        - {{ pin_subpackage("e-antic") }}
+        - {{ pin_subpackage("libeantic") }}
     test:
       imports:
         - pyeantic
@@ -81,8 +81,8 @@ about:
   license_file: COPYING
   summary: embedded algebraic number fields
   description: |
-    E-ANTIC is a C/C++ library to deal with real embedded number fields built
-    on top of ANTIC. Its aim is to have as fast as possible exact arithmetic
+    e-antic is a C/C++ library to deal with real embedded number fields built
+    on top of ANTIC. It aims to privode the fastest possible exact arithmetic
     operations and comparisons.
   dev_url: https://github.com/flatsurf/e-antic
 


### PR DESCRIPTION
to fix run_exports, see https://github.com/conda-forge/e-antic-feedstock/issues/27

Downstream packages (likely none yet in conda-forge) need to change
their dependencies from e-antic to libeantic. Otherwise, they pull in
both the C/C++ library and the Python library.

Fixes #27.