### PR TITLE
Rebuild for libboost 1.82

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -26,11 +26,6 @@ jobs:
   timeoutInMinutes: 360
 
   steps:
-  - script: |
-         rm -rf /opt/ghc
-         df -h
-    displayName: Manage disk space
-
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -2,8 +2,6 @@ antic:
 - '0.2'
 arb:
 - '2.23'
-boost_cpp:
-- 1.78.0
 cdt_name:
 - cos6
 channel_sources:
@@ -13,21 +11,22 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 libflint:
 - '2.9'
 pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+- 3.11.* *_cpython
 - 3.8.* *_cpython
 - 3.9.* *_cpython
 target_platform:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -4,8 +4,6 @@ antic:
 - '0.2'
 arb:
 - '2.23'
-boost_cpp:
-- 1.78.0
 cdt_arch:
 - aarch64
 cdt_name:
@@ -17,21 +15,22 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 libflint:
 - '2.9'
 pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+- 3.11.* *_cpython
 - 3.8.* *_cpython
 - 3.9.* *_cpython
 target_platform:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -2,8 +2,6 @@ antic:
 - '0.2'
 arb:
 - '2.23'
-boost_cpp:
-- 1.78.0
 cdt_name:
 - cos7
 channel_sources:
@@ -13,15 +11,12 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gmp:
 - '6'
 libflint:
 - '2.9'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 target_platform:
 - linux-ppc64le

--- a/.ci_support/migrations/boost_cpp_to_libboost.yaml
+++ b/.ci_support/migrations/boost_cpp_to_libboost.yaml
@@ -1,0 +1,21 @@
+migrator_ts: 1695775149
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+  commit_message: "Rebuild for libboost 1.82"
+  # limit the number of prs for ramp-up
+  pr_limit: 20
+  max_solver_attempts: 3  # this will make the bot retry "not solvable" stuff 3 times
+libboost_devel:
+  - 1.82
+# This migration is matched with a piggy-back migrator
+# (see https://github.com/regro/cf-scripts/pull/1668)
+# that will replace boost-cpp with libboost-devel
+boost_cpp:
+  - 1.82
+# same for boost -> libboost-python-devel
+libboost_python_devel:
+  - 1.82
+boost:
+  - 1.82

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -4,8 +4,6 @@ antic:
 - '0.2'
 arb:
 - '2.23'
-boost_cpp:
-- 1.78.0
 channel_sources:
 - conda-forge
 channel_targets:
@@ -16,18 +14,19 @@ cxx_compiler_version:
 - '14'
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 libflint:
 - '2.9'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+- 3.11.* *_cpython
 - 3.8.* *_cpython
 - 3.9.* *_cpython
 target_platform:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -4,8 +4,6 @@ antic:
 - '0.2'
 arb:
 - '2.23'
-boost_cpp:
-- 1.78.0
 channel_sources:
 - conda-forge
 channel_targets:
@@ -16,18 +14,19 @@ cxx_compiler_version:
 - '14'
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 libflint:
 - '2.9'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+- 3.11.* *_cpython
 - 3.8.* *_cpython
 - 3.9.* *_cpython
 target_platform:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,11 +31,10 @@ pkgs_dirs:
 
 CONDARC
 
-
-mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
-mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
+    pip mamba conda-build boa conda-forge-ci-setup=3
+mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
+    pip mamba conda-build boa conda-forge-ci-setup=3
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/.scripts/create_conda_build_artifacts.sh
+++ b/.scripts/create_conda_build_artifacts.sh
@@ -79,8 +79,8 @@ if [[ ! -z "$BLD_ARTIFACT_PREFIX" ]]; then
         echo "##vso[task.setVariable variable=BLD_ARTIFACT_NAME]$BLD_ARTIFACT_NAME"
         echo "##vso[task.setVariable variable=BLD_ARTIFACT_PATH]$BLD_ARTIFACT_PATH"
     elif [[ "$CI" == "github_actions" ]]; then
-        echo "::set-output name=BLD_ARTIFACT_NAME::$BLD_ARTIFACT_NAME"
-        echo "::set-output name=BLD_ARTIFACT_PATH::$BLD_ARTIFACT_PATH"
+        echo "BLD_ARTIFACT_NAME=$BLD_ARTIFACT_NAME" >> $GITHUB_OUTPUT
+        echo "BLD_ARTIFACT_PATH=$BLD_ARTIFACT_PATH" >> $GITHUB_OUTPUT
     fi
 fi
 
@@ -107,7 +107,7 @@ if [[ ! -z "$ENV_ARTIFACT_PREFIX" ]]; then
         echo "##vso[task.setVariable variable=ENV_ARTIFACT_NAME]$ENV_ARTIFACT_NAME"
         echo "##vso[task.setVariable variable=ENV_ARTIFACT_PATH]$ENV_ARTIFACT_PATH"
     elif [[ "$CI" == "github_actions" ]]; then
-        echo "::set-output name=ENV_ARTIFACT_NAME::$ENV_ARTIFACT_NAME"
-        echo "::set-output name=ENV_ARTIFACT_PATH::$ENV_ARTIFACT_PATH"
+        echo "ENV_ARTIFACT_NAME=$ENV_ARTIFACT_NAME" >> $GITHUB_OUTPUT
+        echo "ENV_ARTIFACT_PATH=$ENV_ARTIFACT_PATH" >> $GITHUB_OUTPUT
     fi
 fi

--- a/.scripts/logging_utils.sh
+++ b/.scripts/logging_utils.sh
@@ -12,7 +12,7 @@ function startgroup {
             echo "##[group]$1";;
         travis )
             echo "$1"
-            echo -en 'travis_fold:start:'"${1// /}"'\\r';;
+            echo -en 'travis_fold:start:'"${1// /}"'\r';;
         github_actions )
             echo "::group::$1";;
         * )
@@ -28,7 +28,7 @@ function endgroup {
         azure )
             echo "##[endgroup]";;
         travis )
-            echo -en 'travis_fold:end:'"${1// /}"'\\r';;
+            echo -en 'travis_fold:end:'"${1// /}"'\r';;
         github_actions )
             echo "::endgroup::";;
     esac

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -23,10 +23,10 @@ bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
 
-mamba install --update-specs --quiet --yes --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
-mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+mamba install --update-specs --quiet --yes --channel conda-forge --strict-channel-priority \
+    pip mamba conda-build boa conda-forge-ci-setup=3
+mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
+    pip mamba conda-build boa conda-forge-ci-setup=3
 
 
 
@@ -55,11 +55,6 @@ source run_conda_forge_build_setup
 echo -e "\n\nMaking the build clobber file"
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
 
-if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
-    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
-fi
-
-
 if [[ -f LICENSE.txt ]]; then
   cp LICENSE.txt "recipe/recipe-scripts-license.txt"
 fi
@@ -75,6 +70,11 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
+
+    if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+    fi
+
     conda mambabuild ./recipe -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-About e-antic
-=============
+About e-antic-feedstock
+=======================
+
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/e-antic-feedstock/blob/main/LICENSE.txt)
 
 Home: https://github.com/flatsurf/e-antic
 
 Package license: LGPL-3.0-or-later
-
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/e-antic-feedstock/blob/main/LICENSE.txt)
 
 Summary: embedded algebraic number fields
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,6 @@
+# pin clang<15 because cppyy (and cling) need an old enough libcxx, see
+# https://github.com/conda-forge/cppyy-feedstock/blob/main/recipe/meta.yaml
+c_compiler_version:        # [osx]
+  - 14                     # [osx]
+cxx_compiler_version:      # [osx]
+  - 14                     # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,7 +61,7 @@ outputs:
         - gnuconfig  # [unix]
         - {{ compiler('cxx') }}
       host:
-        - libboost-devel
+        - libboost-headers
         - python
         - cppyy
         - cppyythonizations

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: ae12cb87f09478f49c4acdf0f3ff888dc556267614c0a5a3bc8bfaa41b22deef
 
 build:
-  number: 0
+  number: 1
   # Upstream doesn't support MSVC yet.
   skip: true  # [win]
 
@@ -30,7 +30,7 @@ outputs:
         - {{ compiler('cxx') }}
       host:
         - antic
-        - boost-cpp
+        - libboost-headers
         - gmp       # [unix]
         - mpir      # [win]
         - arb
@@ -58,7 +58,7 @@ outputs:
         - gnuconfig  # [unix]
         - {{ compiler('cxx') }}
       host:
-        - boost-cpp
+        - libboost-devel
         - python
         - cppyy
         - cppyythonizations
@@ -67,7 +67,6 @@ outputs:
         - pytest
         - {{ pin_subpackage("libeantic") }}
       run:
-        - boost-cpp
         - python
         - cppyy
         - cppyythonizations

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,6 +42,7 @@ outputs:
         - test -f $PREFIX/lib/libeanticxx.so         # [linux]
         - test -f $PREFIX/lib/libeantic.dylib        # [osx]
         - test -f $PREFIX/lib/libeanticxx.dylib      # [osx]
+
   - name: pyeantic
     script: build-pyeantic.sh
     build:
@@ -71,6 +72,7 @@ outputs:
         - cppyy
         - cppyythonizations
         - gmpxxyy
+        - libboost-headers
         # A subpackage does not see the run_exports of another subpackage:
         # https://github.com/conda/conda-build/issues/3478
         - {{ pin_subpackage("libeantic") }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,6 +48,8 @@ outputs:
     build:
       # cppyy is not available on ppc64le
       skip: true  # [ppc64le]
+      # cppyy is not available on aarch64
+      skip: true  # [aarch64]
     requirements:
       build:
         - python                              # [build_platform != target_platform]


### PR DESCRIPTION
Bot failed, likely due to cling requiring a too-old libcxx on osx.